### PR TITLE
[ Ljh/#4 ] 맞팔로우 안된 유저 맞팔로우 

### DIFF
--- a/AdvancedWebProject/src/Types/UserInfoTypes.ts
+++ b/AdvancedWebProject/src/Types/UserInfoTypes.ts
@@ -2,7 +2,6 @@ export interface FollowerFollowingType {
   login: string;
   avatar_url: string;
 }
-
 export interface UserInfo {
   pat: string;
   username: string;

--- a/AdvancedWebProject/src/components/FollowerList.tsx
+++ b/AdvancedWebProject/src/components/FollowerList.tsx
@@ -9,7 +9,7 @@ import { followUser } from "lib/api";
 
 const FollowerList = () => {
   const userInfo = useRecoilValue(userInfoState);
-  console.log(userInfo);
+
   const { NonFollowingList } = useGetAccountInfo(
     userInfo.pat,
     userInfo.username

--- a/AdvancedWebProject/src/components/FollowerList.tsx
+++ b/AdvancedWebProject/src/components/FollowerList.tsx
@@ -2,15 +2,26 @@ import { useGetAccountInfo } from "lib/hooks/useGetAccountInfo";
 import { useRecoilValue } from "recoil";
 import { userInfoState } from "Recoil/atom";
 import styled from "styled-components";
-
+import { useMutation } from "@tanstack/react-query";
+import { UserInfo } from "Types/UserInfoTypes";
+import { followUser } from "lib/api";
 //상대가 팔로우 했는데 내가 안한 리스트
 
 const FollowerList = () => {
   const userInfo = useRecoilValue(userInfoState);
+  console.log(userInfo);
   const { NonFollowingList } = useGetAccountInfo(
     userInfo.pat,
     userInfo.username
   );
+
+  const useReqFollowing = useMutation<any, unknown, UserInfo>(followUser);
+
+  const { mutate, isLoading, isError, error, isSuccess } = useReqFollowing;
+
+  const onClickBtn = (nonFollowUserName: string) => {
+    mutate({ username: nonFollowUserName, pat: userInfo.pat });
+  };
   return (
     <>
       <StFollowingCardWrapper>
@@ -19,7 +30,9 @@ const FollowerList = () => {
             return (
               <StFollowingCard key={idx}>
                 <p>{nonFollowingPerson}</p>
-                <button>맞팔로우하기</button>
+                <button onClick={() => onClickBtn(nonFollowingPerson)}>
+                  맞팔로우하기
+                </button>
               </StFollowingCard>
             );
           })}

--- a/AdvancedWebProject/src/components/FollowerList.tsx
+++ b/AdvancedWebProject/src/components/FollowerList.tsx
@@ -7,12 +7,10 @@ import styled from "styled-components";
 
 const FollowerList = () => {
   const userInfo = useRecoilValue(userInfoState);
-  console.log(userInfo);
   const { NonFollowingList } = useGetAccountInfo(
     userInfo.pat,
     userInfo.username
   );
-
   return (
     <>
       <StFollowingCardWrapper>

--- a/AdvancedWebProject/src/components/FollowerList.tsx
+++ b/AdvancedWebProject/src/components/FollowerList.tsx
@@ -2,14 +2,14 @@ import { useGetAccountInfo } from "lib/hooks/useGetAccountInfo";
 import { useRecoilValue } from "recoil";
 import { userInfoState } from "Recoil/atom";
 import styled from "styled-components";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { UserInfo } from "Types/UserInfoTypes";
 import { followUser } from "lib/api";
-//상대가 팔로우 했는데 내가 안한 리스트
+import { useEffect } from "react";
 
 const FollowerList = () => {
   const userInfo = useRecoilValue(userInfoState);
-
+  const queryClient = useQueryClient();
   const { NonFollowingList } = useGetAccountInfo(
     userInfo.pat,
     userInfo.username
@@ -19,8 +19,9 @@ const FollowerList = () => {
 
   const { mutate, isLoading, isError, error, isSuccess } = useReqFollowing;
 
-  const onClickBtn = (nonFollowUserName: string) => {
-    mutate({ username: nonFollowUserName, pat: userInfo.pat });
+  const onClickBtn = async (nonFollowUserName: string) => {
+    await mutate({ username: nonFollowUserName, pat: userInfo.pat });
+    queryClient.invalidateQueries(["followerInfo"]);
   };
   return (
     <>

--- a/AdvancedWebProject/src/lib/api.ts
+++ b/AdvancedWebProject/src/lib/api.ts
@@ -30,7 +30,7 @@ export const getFollowerInfo = async (pat: string, username: string) => {
 
 export const followUser = async (userInfo: UserInfo) => {
   const { data } = await client.put(
-    `/user/following/seojisoosoo`,
+    `/user/following/${userInfo.username}`,
     {},
     {
       headers: {

--- a/AdvancedWebProject/src/lib/api.ts
+++ b/AdvancedWebProject/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { client } from "./axios";
-
+import { UserInfo } from "Types/UserInfoTypes";
 const PER_PAGE = 100;
 
 export const getFollowingInfo = async (pat: string, username: string) => {
@@ -25,5 +25,19 @@ export const getFollowerInfo = async (pat: string, username: string) => {
     }
   );
 
+  return data;
+};
+
+export const followUser = async (userInfo: UserInfo) => {
+  const { data } = await client.put(
+    `/user/following/seojisoosoo`,
+    {},
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `token ${userInfo.pat}`,
+      },
+    }
+  );
   return data;
 };

--- a/AdvancedWebProject/src/lib/hooks/useGetAccountInfo.ts
+++ b/AdvancedWebProject/src/lib/hooks/useGetAccountInfo.ts
@@ -5,7 +5,7 @@ import { FollowerFollowingType } from "Types/UserInfoTypes";
 //팔로잉, 팔로워 정보 한 번에 리턴
 export const useGetAccountInfo = (pat: string, username: string) => {
   const { data: followingInfo } = useQuery(
-    ["followingInfo"],
+    ["followingInfo", pat, username],
     () => getFollowingInfo(pat, username),
     {
       retry: 3,
@@ -13,13 +13,12 @@ export const useGetAccountInfo = (pat: string, username: string) => {
   );
 
   const { data: followerInfo } = useQuery(
-    ["followerInfo"],
+    ["followerInfo", pat, username],
     () => getFollowerInfo(pat, username),
     {
       retry: 3,
     }
   );
-
   const followerNameList =
     followerInfo &&
     followerInfo.map((follower: FollowerFollowingType) => {
@@ -34,6 +33,7 @@ export const useGetAccountInfo = (pat: string, username: string) => {
 
   const nonFollowingList =
     followerNameList &&
+    followingNameList &&
     followerNameList.filter((followerName: string) => {
       if (!followingNameList.includes(followerName)) return followerName;
     });

--- a/AdvancedWebProject/src/lib/hooks/useReqFollowing.ts
+++ b/AdvancedWebProject/src/lib/hooks/useReqFollowing.ts
@@ -1,7 +1,0 @@
-import { useMutation } from "@tanstack/react-query";
-import { followUser } from "lib/api";
-
-// console.log( { mutate, isLoading, isError, error, isSuccess }
-//   `isLoading: ${isLoading}, isError: ${isError}, error: ${error}, isSuccess: ${isSuccess}`
-// );
-// // useMutation의 리턴값을 출력한다.

--- a/AdvancedWebProject/src/lib/hooks/useReqFollowing.ts
+++ b/AdvancedWebProject/src/lib/hooks/useReqFollowing.ts
@@ -1,0 +1,7 @@
+import { useMutation } from "@tanstack/react-query";
+import { followUser } from "lib/api";
+
+// console.log( { mutate, isLoading, isError, error, isSuccess }
+//   `isLoading: ${isLoading}, isError: ${isError}, error: ${error}, isSuccess: ${isSuccess}`
+// );
+// // useMutation의 리턴값을 출력한다.


### PR DESCRIPTION
맞팔로우 돼있지 않는 유저들을 대상으로 맞팔로우하는 기능 구현
## 🔥 Related Issues
resolved #4 

## 💜 작업 내용
- [x] ~ put api를 사용하여 팔로우 기능을 구현했습니다.
- [x] ~ 맞팔로우 버튼 클릭시 아래 맞팔로우 대상 목록을 리렌더링 하도록 했습니다 -> 적용 잘 안됨

## ✅ PR Point

- 맞팔 안된 유저에게 팔로우 요청하는 api
```js
// ✅ lib/api.ts
export const followUser = async (userInfo: UserInfo) => {
  const { data } = await client.put(
    `/user/following/${userInfo.username}`,
    {},
    {
      headers: {
        Accept: "application/vnd.github+json",
        Authorization: `token ${userInfo.pat}`,
      },
    }
  );
  return data;
};

```

- put api를 사용해 데이터를 변경하기 때문에  react query useMutation을 사용하였습니다. 
- 맞팔로우 버튼 클릭시 api요청을 하여 아래 맞팔로우 목록을 리렌더링 하고 싶어서 queryClient.invalidateQueries를 사용했는데 의도한대로 작동하지 않는 것 같습니다.  (굉장히 느리게 최신화되고 있는듯 합니다.)
- recoil, ts, react query 모두 제가 잘 사용했는지 확신을 가지지 못한 것 같아서 멘토님들의 조언이 필요합니다!!!
```
  const queryClient = useQueryClient();
  const { NonFollowingList } = useGetAccountInfo(
    userInfo.pat,
    userInfo.username
  );

  const useReqFollowing = useMutation<any, unknown, UserInfo>(followUser);

  const { mutate, isLoading, isError, error, isSuccess } = useReqFollowing;

  const onClickBtn = async (nonFollowUserName: string) => {
    await mutate({ username: nonFollowUserName, pat: userInfo.pat });
    queryClient.invalidateQueries(["followerInfo"]);
  };
```


## 👀 스크린샷 / GIF / 링크
![image](https://github.com/Deep-Web-Study-Team4/Github-Follower-Ditector/assets/81609304/1b458c81-330b-45c0-a8ad-90483725d7f6)


